### PR TITLE
manifest 与 requirements.txt 同步给 brotli/ddgs 加版本下限

### DIFF
--- a/_manifest.json
+++ b/_manifest.json
@@ -76,12 +76,12 @@
     {
       "type": "python_package",
       "name": "brotli",
-      "version_spec": ""
+      "version_spec": ">=1.0.0"
     },
     {
       "type": "python_package",
       "name": "ddgs",
-      "version_spec": ""
+      "version_spec": ">=9.0.0"
     },
     {
       "type": "python_package",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ trafilatura>=1.6.0
 charset-normalizer>=3.0.0
 lxml-html-clean>=0.1.0
 aiohttp-socks>=0.8.0
-brotli
-ddgs
+brotli>=1.0.0
+ddgs>=9.0.0
 httpx>=0.25.0


### PR DESCRIPTION
## 由 Sourcery 提供的总结

通过添加明确的最低版本，将 `brotli` 和 `ddgs` 的依赖版本约束在 `requirements.txt` 与项目清单（manifest）之间对齐。

错误修复：
- 通过为 `brotli` 和 `ddgs` 强制设置最低版本，防止依赖解析问题。

构建：
- 在 `requirements.txt` 中指定 `brotli` 和 `ddgs` 的下限版本，以匹配清单中的约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align dependency version constraints for brotli and ddgs between requirements.txt and the project manifest by adding explicit minimum versions.

Bug Fixes:
- Prevent dependency resolution issues by enforcing minimum versions for brotli and ddgs.

Build:
- Specify lower-bound versions for brotli and ddgs in requirements.txt to match manifest constraints.

</details>