### PR TITLE
fix(bing): 优化参数集与中英文 query 检索质量

### DIFF
--- a/search_engines/bing.py
+++ b/search_engines/bing.py
@@ -27,7 +27,7 @@ _STOPWORDS_ZH = frozenset({
     "应该", "可以", "能否", "哪个", "哪些", "哪里", "这个", "那个",
 })
 
-_ENGLISH_ONLY_RE = re.compile(r"^[a-z0-9\s\.\?\!,\-\:\;'\"\(\)]+$")
+_ENGLISH_ONLY_RE = re.compile(r"^[a-z0-9\s\.\?\!,\-\:\;'\"\(\)\+#]+$")
 
 
 class BingEngine(BaseSearchEngine):
@@ -92,15 +92,13 @@ class BingEngine(BaseSearchEngine):
         # cn 优先(多数中国大陆用户场景下中文索引最优), www 兜底(海外 IP 时 cn 给空骨架)。
         self.base_urls = ["https://cn.bing.com", "https://www.bing.com"]
         self.region = self.config.get("region", "zh-CN")
-        self.setlang = self.config.get("setlang", "zh")
-        self.count = self.config.get("count", 10)
 
     def _build_keywords(self, query: str) -> List[str]:
         """构建用于相关性过滤的关键词列表,兼容中英文。"""
         if not query:
             return []
         keywords: List[str] = []
-        for seg in re.findall(r"[a-z0-9]+|[\u4e00-\u9fff]+", query.lower()):
+        for seg in re.findall(r"[a-z0-9+#]+|[\u4e00-\u9fff]+", query.lower()):
             if not seg:
                 continue
             if seg[0].isascii():
@@ -157,17 +155,14 @@ class BingEngine(BaseSearchEngine):
         *,
         base_url: Optional[str] = None,
         region: Optional[str] = None,
-        setlang: Optional[str] = None,
         market: Optional[str] = None,
     ) -> str:
         """构建并获取搜索页面 HTML。
 
         Bing 的 query 参数只用 ``q`` + ``adlt`` + ``mkt``,语言偏好走 Accept-Language。
-        ``ensearch=1`` / ``cc`` / ``setlang`` / ``count`` 历史上传过但实测有害或被忽略。
 
         market / region 区分 ``None``(用 self.region 兜底) vs ``""``(明确不传 mkt)。
         """
-        del setlang
         base_url = base_url or self.base_urls[0]
         if market is not None:
             mkt = market
@@ -177,7 +172,7 @@ class BingEngine(BaseSearchEngine):
             mkt = self.region or ""
 
         params: dict[str, str] = {"q": query, "adlt": "off"}
-        if mkt and mkt != "clear":
+        if mkt:
             params["mkt"] = mkt
 
         if mkt and "-" in mkt:
@@ -197,14 +192,13 @@ class BingEngine(BaseSearchEngine):
         """Per-request 抓取,不污染 self.headers,避免并发下 Accept-Language 跨请求泄漏。
 
         与 base._get_html 行为等价,但 headers 用本地 dict 而非共享实例属性。
+        accept_language=None 时保留 base 默认值(en-GB,en;q=0.5),不显式删 header。
         """
         headers = dict(self.headers)
         headers["Referer"] = url
         headers["User-Agent"] = random.choice(USER_AGENTS)
         if accept_language:
             headers["Accept-Language"] = accept_language
-        else:
-            headers.pop("Accept-Language", None)
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url,
@@ -283,19 +277,16 @@ class BingEngine(BaseSearchEngine):
             zh_variant = {
                 "base_url": "https://cn.bing.com",
                 "region": self.region,
-                "setlang": self.setlang,
                 "market": self.region,
             }
             zh_fallback = {
                 "base_url": "https://www.bing.com",
                 "region": self.region,
-                "setlang": self.setlang,
                 "market": self.region,
             }
             en_variant = {
                 "base_url": "https://www.bing.com",
                 "region": "",
-                "setlang": "en",
                 "market": "",
             }
             fetch_variants = [en_variant] if is_english else [zh_variant, zh_fallback, en_variant]

--- a/search_engines/bing.py
+++ b/search_engines/bing.py
@@ -35,8 +35,6 @@ class BingEngine(BaseSearchEngine):
 
     base_urls: List[str]
     region: str
-    setlang: str
-    count: int
 
     SELECTOR_CONFIG: Dict[str, Dict[str, Any]] = {
         "url": {

--- a/search_engines/bing.py
+++ b/search_engines/bing.py
@@ -1,11 +1,14 @@
 import json
 import logging
+import random
 import re
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlencode, urlparse
+
+import aiohttp
 from bs4 import BeautifulSoup
 
-from .base import BaseSearchEngine, SearchResult
+from .base import BaseSearchEngine, SearchResult, USER_AGENTS
 
 logger = logging.getLogger(__name__)
 
@@ -179,16 +182,38 @@ class BingEngine(BaseSearchEngine):
 
         if mkt and "-" in mkt:
             lang = mkt.split("-")[0]
-            self.headers["Accept-Language"] = f"{mkt},{lang};q=0.9"
+            accept_language: Optional[str] = f"{mkt},{lang};q=0.9"
         elif mkt:
-            self.headers["Accept-Language"] = f"{mkt};q=0.9"
+            accept_language = f"{mkt};q=0.9"
         else:
-            self.headers.pop("Accept-Language", None)
+            accept_language = None
 
         query_string = urlencode(params)
         search_url = f"{base_url}/search?{query_string}"
         logger.info(f"Requesting Bing search URL: {search_url}")
-        return await self._get_html(search_url)
+        return await self._fetch(search_url, accept_language=accept_language)
+
+    async def _fetch(self, url: str, *, accept_language: Optional[str] = None) -> str:
+        """Per-request 抓取,不污染 self.headers,避免并发下 Accept-Language 跨请求泄漏。
+
+        与 base._get_html 行为等价,但 headers 用本地 dict 而非共享实例属性。
+        """
+        headers = dict(self.headers)
+        headers["Referer"] = url
+        headers["User-Agent"] = random.choice(USER_AGENTS)
+        if accept_language:
+            headers["Accept-Language"] = accept_language
+        else:
+            headers.pop("Accept-Language", None)
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=self.TIMEOUT),
+                proxy=self.proxy,
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.text()
 
     def _get_link_elements(self, soup: BeautifulSoup) -> List[Any]:
         """获取搜索结果节点，包含主选择器和回退。"""
@@ -253,7 +278,8 @@ class BingEngine(BaseSearchEngine):
             keywords = self._build_keywords(query)
             is_english = bool(_ENGLISH_ONLY_RE.fullmatch(query.lower().strip()))
             # 中文 query: cn 优先(中国大陆 IP 最优),www 兜底(海外 IP 时 cn 空骨架自动 fall through)
-            # 英文 query: 只走 www 不传 mkt(cn 对英文 query 偏返中文翻译/字典页)
+            # 英文 query: 只走 www 不传 mkt(cn 对英文 query 偏返中文翻译/字典页;
+            #            zh_fallback 带 mkt 会触发 Bing 短词命名实体模式,故不作为英文 fallback)
             zh_variant = {
                 "base_url": "https://cn.bing.com",
                 "region": self.region,
@@ -272,7 +298,7 @@ class BingEngine(BaseSearchEngine):
                 "setlang": "en",
                 "market": "",
             }
-            fetch_variants = [en_variant, zh_fallback] if is_english else [zh_variant, zh_fallback, en_variant]
+            fetch_variants = [en_variant] if is_english else [zh_variant, zh_fallback, en_variant]
 
             results: List[SearchResult] = []
             for variant in fetch_variants:

--- a/search_engines/bing.py
+++ b/search_engines/bing.py
@@ -10,6 +10,23 @@ from .base import BaseSearchEngine, SearchResult
 logger = logging.getLogger(__name__)
 
 
+# 高频词过滤,目的是让相关性判定有意义。
+_STOPWORDS_EN = frozenset({
+    "a", "an", "the", "and", "or", "but", "if", "of", "in", "on", "at", "to",
+    "for", "from", "by", "with", "is", "are", "was", "were", "be", "been",
+    "being", "has", "have", "had", "do", "does", "did", "will", "would",
+    "can", "could", "should", "shall", "may", "might", "must", "this", "that",
+    "these", "those", "it", "its", "as", "we", "you", "they", "he", "she",
+})
+_STOPWORDS_ZH = frozenset({
+    "的", "了", "是", "在", "我", "你", "他", "她", "它", "和", "与", "或",
+    "但", "如果", "怎样", "怎么", "如何", "什么", "为什么", "为何", "是否",
+    "应该", "可以", "能否", "哪个", "哪些", "哪里", "这个", "那个",
+})
+
+_ENGLISH_ONLY_RE = re.compile(r"^[a-z0-9\s\.\?\!,\-\:\;'\"\(\)]+$")
+
+
 class BingEngine(BaseSearchEngine):
     """Bing 搜索引擎实现"""
 
@@ -69,33 +86,47 @@ class BingEngine(BaseSearchEngine):
 
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(config)
+        # cn 优先(多数中国大陆用户场景下中文索引最优), www 兜底(海外 IP 时 cn 给空骨架)。
         self.base_urls = ["https://cn.bing.com", "https://www.bing.com"]
         self.region = self.config.get("region", "zh-CN")
         self.setlang = self.config.get("setlang", "zh")
         self.count = self.config.get("count", 10)
 
     def _build_keywords(self, query: str) -> List[str]:
-        """构建用于相关性过滤的关键词列表，兼容中英文。"""
+        """构建用于相关性过滤的关键词列表,兼容中英文。"""
         if not query:
             return []
-        pieces: List[str] = []
-        for token in re.split(r"\s+", query.lower().strip()):
-            if not token:
+        keywords: List[str] = []
+        for seg in re.findall(r"[a-z0-9]+|[\u4e00-\u9fff]+", query.lower()):
+            if not seg:
                 continue
-            words = re.findall(r"[a-z0-9]+|[\u4e00-\u9fff]+", token)
-            if words:
-                pieces.extend(words)
+            if seg[0].isascii():
+                if seg in _STOPWORDS_EN or len(seg) < 2:
+                    continue
+                keywords.append(seg)
             else:
-                pieces.append(token)
-        return [p for p in pieces if len(p) >= 2]
+                if len(seg) <= 4:
+                    if seg not in _STOPWORDS_ZH:
+                        keywords.append(seg)
+                else:
+                    # 长中文段切 bigram,避免整段一坨永远不命中
+                    for i in range(len(seg) - 1):
+                        bigram = seg[i : i + 2]
+                        if bigram not in _STOPWORDS_ZH:
+                            keywords.append(bigram)
+        seen: set[str] = set()
+        return [kw for kw in keywords if not (kw in seen or seen.add(kw))]
 
     def _is_relevant(self, title: str, snippet: str, url: str, keywords: List[str]) -> bool:
-        """粗粒度过滤：标题/摘要/URL 命中至少一个关键词即通过。"""
+        """命中数 ≥ 1 即通过。
+
+        阈值保持宽松——目标是滤掉与 query 完全无关的广告/导航页,不是修正 Bing 的跑偏。
+        Bing 严重跑偏的 case(诺贝尔奖/best 字典)交给下游 LLM 或上层 EngineChain 切其他引擎。
+        """
         if not keywords:
             return True
         text = f"{title} {snippet} {url}".lower()
-        match_count = sum(1 for kw in keywords if kw in text)
-        return match_count >= 1
+        return any(kw in text for kw in keywords)
 
     def _is_blocked(self, url: str) -> bool:
         """域名黑名单过滤。"""
@@ -126,31 +157,33 @@ class BingEngine(BaseSearchEngine):
         setlang: Optional[str] = None,
         market: Optional[str] = None,
     ) -> str:
-        """构建并获取搜索页面的 HTML 内容。
+        """构建并获取搜索页面 HTML。
 
-        Args:
-            query: 搜索查询词。
-            base_url: 基础域名，默认先用 cn，再回退 www。
-            region: 区域代码（cc），影响市场。
-            setlang: 语言参数。
-            market: 市场参数（mkt），可用于强制 en-US 等。
+        Bing 的 query 参数只用 ``q`` + ``adlt`` + ``mkt``,语言偏好走 Accept-Language。
+        ``ensearch=1`` / ``cc`` / ``setlang`` / ``count`` 历史上传过但实测有害或被忽略。
 
-        Returns:
-            HTML 文本。
+        market / region 区分 ``None``(用 self.region 兜底) vs ``""``(明确不传 mkt)。
         """
+        del setlang
         base_url = base_url or self.base_urls[0]
-        region = region or self.region
-        setlang = setlang or self.setlang
-        params = {
-            "q": query,
-            "setlang": setlang,
-            "count": str(min(self.count, 50)),
-            "ensearch": "1",
-        }
-        if region:
-            params["cc"] = region.split("-")[0] if "-" in region else region
-        if market:
-            params["mkt"] = market
+        if market is not None:
+            mkt = market
+        elif region is not None:
+            mkt = region
+        else:
+            mkt = self.region or ""
+
+        params: dict[str, str] = {"q": query, "adlt": "off"}
+        if mkt and mkt != "clear":
+            params["mkt"] = mkt
+
+        if mkt and "-" in mkt:
+            lang = mkt.split("-")[0]
+            self.headers["Accept-Language"] = f"{mkt},{lang};q=0.9"
+        elif mkt:
+            self.headers["Accept-Language"] = f"{mkt};q=0.9"
+        else:
+            self.headers.pop("Accept-Language", None)
 
         query_string = urlencode(params)
         search_url = f"{base_url}/search?{query_string}"
@@ -196,6 +229,11 @@ class BingEngine(BaseSearchEngine):
             url_elem = self._select_with_fallback(link, "url")
             text_elem = self._select_with_fallback(link, "text")
 
+            # Bing 在 snippet 里插入 "🌐 翻译此页" 等装饰 span,extract 前去掉免得污染。
+            if text_elem is not None:
+                for icon in text_elem.select("span.algoSlug_icon"):
+                    icon.decompose()
+
             title = self.tidy_text(title_elem.text) if title_elem else ""
             url_raw = url_elem.get("href") if url_elem else ""
             url = self._normalize_url(url_raw)
@@ -206,23 +244,35 @@ class BingEngine(BaseSearchEngine):
         return results
 
     async def search(self, query: str, num_results: int) -> List[SearchResult]:
-        """执行搜索，使用多区域尝试与选择器回退。"""
+        """多 variant 顺序尝试,首个非空结果 break。过滤后 0 时返回空,交给上层换引擎。
+
+        英文 query 不传 mkt——实测 mkt=en-US 会触发 Bing 短词命名实体模式,
+        "best practices for python asyncio timeout" 会被搜成 "best" 返字典/Best Buy。
+        """
         try:
             keywords = self._build_keywords(query)
-            fetch_variants = [
-                {
-                    "base_url": self.base_urls[0],
-                    "region": self.region,
-                    "setlang": self.setlang,
-                    "market": self.region,
-                },
-                {
-                    "base_url": self.base_urls[1] if len(self.base_urls) > 1 else self.base_urls[0],
-                    "region": "en-US",
-                    "setlang": "en",
-                    "market": "en-US",
-                },
-            ]
+            is_english = bool(_ENGLISH_ONLY_RE.fullmatch(query.lower().strip()))
+            # 中文 query: cn 优先(中国大陆 IP 最优),www 兜底(海外 IP 时 cn 空骨架自动 fall through)
+            # 英文 query: 只走 www 不传 mkt(cn 对英文 query 偏返中文翻译/字典页)
+            zh_variant = {
+                "base_url": "https://cn.bing.com",
+                "region": self.region,
+                "setlang": self.setlang,
+                "market": self.region,
+            }
+            zh_fallback = {
+                "base_url": "https://www.bing.com",
+                "region": self.region,
+                "setlang": self.setlang,
+                "market": self.region,
+            }
+            en_variant = {
+                "base_url": "https://www.bing.com",
+                "region": "",
+                "setlang": "en",
+                "market": "",
+            }
+            fetch_variants = [en_variant, zh_fallback] if is_english else [zh_variant, zh_fallback, en_variant]
 
             results: List[SearchResult] = []
             for variant in fetch_variants:
@@ -262,7 +312,6 @@ class BingEngine(BaseSearchEngine):
                 "FORM": "HDRSC2"
             }
 
-            # 尝试多个Bing图片搜索域名
             html = ""
             successful_base_url = ""
             for base_url in self.base_urls:
@@ -284,12 +333,10 @@ class BingEngine(BaseSearchEngine):
             soup = BeautifulSoup(html, "html.parser")
             results = []
 
-            # 解析图片结果 - Bing图片搜索的HTML结构
             image_elements = soup.select("a.iusc")
 
             for elem in image_elements[:num_results]:
                 try:
-                    # 尝试从m属性获取JSON数据
                     m_attr = elem.get("m")
                     if m_attr:
                         try:
@@ -306,15 +353,12 @@ class BingEngine(BaseSearchEngine):
                                 })
                                 continue
                         except json.JSONDecodeError:
-                            # JSON解析失败，尝试备用方法
                             pass
 
-                    # 备用解析：从img标签获取
                     img_elem = elem.find("img")
                     if img_elem:
                         image_url = img_elem.get("src") or img_elem.get("data-src")
                         if image_url:
-                            # 处理相对路径
                             if image_url.startswith("//"):
                                 image_url = "https:" + image_url
                             elif image_url.startswith("/") and successful_base_url:


### PR DESCRIPTION
- 参数集精简为 q + adlt + mkt,移除有害/被忽略的 ensearch/cc/setlang/count
- 语言偏好走 Accept-Language 头而非 setlang query 参数
- market/region 区分 None(兜底 self.region) 与 "" (明确不传 mkt)
- 英文 query 走 www 不传 mkt,避开 Bing 短词命名实体模式 (mkt=en-US 会把 "best practices for python asyncio timeout" 搜成 "best" 返字典/Best Buy)
- 中文 query 走 cn 优先 + www 兜底,匹配中国大陆 IP 主场景
- _build_keywords 中文长段切 bigram,加入中英文 stopwords
- _parse_page_results 移除 snippet 中 span.algoSlug_icon 翻译装饰

## Summary by Sourcery

优化必应网页搜索在中文和英文查询下的行为和相关性，同时减少参数使用并改进按请求的 HTTP 处理方式。

新功能：
- 对纯英文查询，通过全球版必应域名进行路由，而不发送显式的 market 参数。
- 引入按请求的 HTTP 获取机制，为每个请求随机化 User-Agent，并可选地设置 Accept-Language 头，以避免跨请求的 Header 污染。

缺陷修复：
- 调整英文和中文查询的域名与 market 选择，避免触发必应对短查询的命名实体行为，防止结果退化为词典或品牌页面。

改进：
- 使用语言特定的停用词和中文二元切分优化关键词抽取，以提升相关性过滤效果。
- 简化必应查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 Accept-Language 推断语言偏好，而不是使用 `setlang`。
- 区分地区与 market 的处理方式，以更好地控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，通过移除必应翻译装饰元素来清理搜索摘要内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Bing web search behavior and relevance for Chinese and English queries while reducing parameter usage and improving per-request HTTP handling.

New Features:
- Route purely English queries through the global Bing domain without sending an explicit market parameter.
- Introduce per-request HTTP fetching with randomized User-Agent and optional Accept-Language headers to avoid cross-request header contamination.

Bug Fixes:
- Adjust domain and market selection for English and Chinese queries to avoid Bing short-query named-entity behavior that degrades results into dictionary or brand pages.

Enhancements:
- Refine keyword extraction using language-specific stopwords and Chinese bigram segmentation to improve relevance filtering.
- Simplify Bing query construction to rely only on q, adlt, and mkt parameters and infer language preference via Accept-Language instead of setlang.
- Differentiate region and market handling to better control when the mkt parameter is sent or omitted.
- Clean search snippets by removing Bing translation decoration elements before building search results.

</details>

新功能：
- 识别纯英文查询，将其通过全球 Bing 域名路由，并且不显式设置 market 参数。
- 引入按请求级别的 HTTP 抓取机制，使用随机化的 User-Agent，并可选发送 Accept-Language 头，以避免跨请求污染。

缺陷修复：
- 通过调整英文和中文查询在市场（market）与域名选择上的策略，避免 Bing 对短英文查询采用命名实体模式，导致搜索结果退化为词典或品牌结果的问题。

改进项：
- 使用语言特定的停用词和中文双字分词优化关键词抽取，以提升相关性过滤效果。
- 调整 Bing 查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 `Accept-Language` 头而非 `setlang` 推导语言偏好。
- 区分 region 和 market 的处理，用以精细控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，清理摘要片段，移除 Bing 翻译装饰元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化必应网页搜索在中文和英文查询下的行为和相关性，同时减少参数使用并改进按请求的 HTTP 处理方式。

新功能：
- 对纯英文查询，通过全球版必应域名进行路由，而不发送显式的 market 参数。
- 引入按请求的 HTTP 获取机制，为每个请求随机化 User-Agent，并可选地设置 Accept-Language 头，以避免跨请求的 Header 污染。

缺陷修复：
- 调整英文和中文查询的域名与 market 选择，避免触发必应对短查询的命名实体行为，防止结果退化为词典或品牌页面。

改进：
- 使用语言特定的停用词和中文二元切分优化关键词抽取，以提升相关性过滤效果。
- 简化必应查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 Accept-Language 推断语言偏好，而不是使用 `setlang`。
- 区分地区与 market 的处理方式，以更好地控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，通过移除必应翻译装饰元素来清理搜索摘要内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Bing web search behavior and relevance for Chinese and English queries while reducing parameter usage and improving per-request HTTP handling.

New Features:
- Route purely English queries through the global Bing domain without sending an explicit market parameter.
- Introduce per-request HTTP fetching with randomized User-Agent and optional Accept-Language headers to avoid cross-request header contamination.

Bug Fixes:
- Adjust domain and market selection for English and Chinese queries to avoid Bing short-query named-entity behavior that degrades results into dictionary or brand pages.

Enhancements:
- Refine keyword extraction using language-specific stopwords and Chinese bigram segmentation to improve relevance filtering.
- Simplify Bing query construction to rely only on q, adlt, and mkt parameters and infer language preference via Accept-Language instead of setlang.
- Differentiate region and market handling to better control when the mkt parameter is sent or omitted.
- Clean search snippets by removing Bing translation decoration elements before building search results.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化必应网页搜索在中文和英文查询下的行为和相关性，同时减少参数使用并改进按请求的 HTTP 处理方式。

新功能：
- 对纯英文查询，通过全球版必应域名进行路由，而不发送显式的 market 参数。
- 引入按请求的 HTTP 获取机制，为每个请求随机化 User-Agent，并可选地设置 Accept-Language 头，以避免跨请求的 Header 污染。

缺陷修复：
- 调整英文和中文查询的域名与 market 选择，避免触发必应对短查询的命名实体行为，防止结果退化为词典或品牌页面。

改进：
- 使用语言特定的停用词和中文二元切分优化关键词抽取，以提升相关性过滤效果。
- 简化必应查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 Accept-Language 推断语言偏好，而不是使用 `setlang`。
- 区分地区与 market 的处理方式，以更好地控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，通过移除必应翻译装饰元素来清理搜索摘要内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Bing web search behavior and relevance for Chinese and English queries while reducing parameter usage and improving per-request HTTP handling.

New Features:
- Route purely English queries through the global Bing domain without sending an explicit market parameter.
- Introduce per-request HTTP fetching with randomized User-Agent and optional Accept-Language headers to avoid cross-request header contamination.

Bug Fixes:
- Adjust domain and market selection for English and Chinese queries to avoid Bing short-query named-entity behavior that degrades results into dictionary or brand pages.

Enhancements:
- Refine keyword extraction using language-specific stopwords and Chinese bigram segmentation to improve relevance filtering.
- Simplify Bing query construction to rely only on q, adlt, and mkt parameters and infer language preference via Accept-Language instead of setlang.
- Differentiate region and market handling to better control when the mkt parameter is sent or omitted.
- Clean search snippets by removing Bing translation decoration elements before building search results.

</details>

新功能：
- 识别纯英文查询，将其通过全球 Bing 域名路由，并且不显式设置 market 参数。
- 引入按请求级别的 HTTP 抓取机制，使用随机化的 User-Agent，并可选发送 Accept-Language 头，以避免跨请求污染。

缺陷修复：
- 通过调整英文和中文查询在市场（market）与域名选择上的策略，避免 Bing 对短英文查询采用命名实体模式，导致搜索结果退化为词典或品牌结果的问题。

改进项：
- 使用语言特定的停用词和中文双字分词优化关键词抽取，以提升相关性过滤效果。
- 调整 Bing 查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 `Accept-Language` 头而非 `setlang` 推导语言偏好。
- 区分 region 和 market 的处理，用以精细控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，清理摘要片段，移除 Bing 翻译装饰元素。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化必应网页搜索在中文和英文查询下的行为和相关性，同时减少参数使用并改进按请求的 HTTP 处理方式。

新功能：
- 对纯英文查询，通过全球版必应域名进行路由，而不发送显式的 market 参数。
- 引入按请求的 HTTP 获取机制，为每个请求随机化 User-Agent，并可选地设置 Accept-Language 头，以避免跨请求的 Header 污染。

缺陷修复：
- 调整英文和中文查询的域名与 market 选择，避免触发必应对短查询的命名实体行为，防止结果退化为词典或品牌页面。

改进：
- 使用语言特定的停用词和中文二元切分优化关键词抽取，以提升相关性过滤效果。
- 简化必应查询构造，仅依赖 `q`、`adlt` 和 `mkt` 参数，并通过 Accept-Language 推断语言偏好，而不是使用 `setlang`。
- 区分地区与 market 的处理方式，以更好地控制何时发送或省略 `mkt` 参数。
- 在构建搜索结果前，通过移除必应翻译装饰元素来清理搜索摘要内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Bing web search behavior and relevance for Chinese and English queries while reducing parameter usage and improving per-request HTTP handling.

New Features:
- Route purely English queries through the global Bing domain without sending an explicit market parameter.
- Introduce per-request HTTP fetching with randomized User-Agent and optional Accept-Language headers to avoid cross-request header contamination.

Bug Fixes:
- Adjust domain and market selection for English and Chinese queries to avoid Bing short-query named-entity behavior that degrades results into dictionary or brand pages.

Enhancements:
- Refine keyword extraction using language-specific stopwords and Chinese bigram segmentation to improve relevance filtering.
- Simplify Bing query construction to rely only on q, adlt, and mkt parameters and infer language preference via Accept-Language instead of setlang.
- Differentiate region and market handling to better control when the mkt parameter is sent or omitted.
- Clean search snippets by removing Bing translation decoration elements before building search results.

</details>

</details>

</details>