### PR TITLE
fix: 将 rewrite_output 延迟导入移至顶层，避免热重载后相对导入失败

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -26,6 +26,7 @@ from .pipelines.llm_runner import LLMRunner
 from .pipelines.search_pipeline import SearchPipeline
 from .pipelines.url_pipeline import UrlPipeline, is_url
 from .pipelines.zhihu_extractor import ZhihuExtractor
+from .tools.rewrite_output import ALLOWED_TAVILY_TOPICS
 from .translators.nbnhhsh import NbnhhshTranslator
 
 
@@ -211,8 +212,6 @@ class GoogleSearchPlugin(MaiBotPlugin):
             return {"name": "web_search", "content": ""}
 
         # tavily_topic 校验
-        from .tools.rewrite_output import ALLOWED_TAVILY_TOPICS
-
         normalized_topic = (tavily_topic or "").strip().lower()
         topic_override = normalized_topic if normalized_topic in ALLOWED_TAVILY_TOPICS else None
 


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 通过避免在网页搜索处理程序中对允许的 Tavily 主题进行按调用的相对导入，防止热重载之后出现失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent failures after hot reload by avoiding per-call relative imports of the allowed Tavily topics in the web search handler.

</details>