### PR TITLE
feat(search): 支持博查搜索后端

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 这是一个搜索插件，还有缩写翻译，还有图片搜索
 
-> **v4.0.0 升级提示**：配置文件结构有调整，v3.x 用户请按本 README **🆙 v3.x → v4 升级**一节修改 `config.toml` 后再启用。
+> **v4.0.1 升级提示**：新增博查 Web Search 后端，默认关闭。需要使用时请配置 `bocha_api_key` 或环境变量 `BOCHA_API_KEY`，并启用 `bocha_enabled`。
 
 ## 已更新[tavily](https://app.tavily.com)以及[You](https://you.com/platform)搜索引擎，很好用:)
 tavily搜索引擎可以前往[官网](https://app.tavily.com)注册后获得密钥
 
 You搜索引擎需要在[官网](https://you.com/platform) 获取 API Key；Live News / Images 为 early access，需账号权限）
+博查搜索引擎需要在[博查开放平台](https://open.bochaai.com/)获取 API Key，适合中文网络搜索场景。
 ## 以上二者均可以使用作者自建的免费注册临时[邮箱1](https://xiaowan258.me)或[邮箱2](https://mail.xiaowan.me)注册
 
 <img width="735" height="308" alt="image" src="https://github.com/user-attachments/assets/9bc86124-b3a8-43e0-addb-1884133658c2" />
@@ -26,12 +27,12 @@ pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 
 ## 🆙 v3.x → v4 升级
 
-如果你是从 v3.x 升级到 v4.0.0，请手动调整你的 `config.toml`（配置文件 gitignored，升级时不会被覆盖），主要有三处变化：
+如果你是从 v3.x 升级到当前版本，请手动调整你的 `config.toml`（配置文件 gitignored，升级时不会被覆盖），主要有三处变化：
 
 1. **section 重命名**：`[model_config]` → `[models]`（其中字段名不变，只是 section 名变更）
 2. **新增 section**：`[translation]`（缩写翻译相关参数，不写也行，会用默认值）
 3. **删除 section**：`[storage]` 整段可以删除（搜索结果现在由麦麦内部统一记录到 `tool_records`，不再由插件自己写库）
-4. **`[plugin]` 段新增 `config_version = "4.0.0"`**（必填，麦麦校验配置版本时会用）
+4. **`[plugin]` 段新增 `config_version = "4.0.1"`**（必填，麦麦校验配置版本时会用）
 
 升级最快的做法：直接删掉旧 `config.toml`，让插件首次启动时自动重新生成 v4 默认配置；再把你原来的 API key / 代理 等设置项搬过去即可。
 
@@ -39,7 +40,7 @@ pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 
 1.  **接收问题**: 插件接收到用户的原始问题。
 2.  **查询重写**: 插件内部的LLM结合聊天上下文，将原始问题重写为一个或多个精确的搜索关键词。
-3.  **后端搜索**: 使用重写后的关键词，调用Google、Bing、Tavily 等搜索引擎执行搜索（多引擎自动降级）。
+3.  **后端搜索**: 使用重写后的关键词，调用Google、Bing、Tavily、博查等搜索引擎执行搜索（多引擎自动降级）。
 4.  **内容抓取**: (可选) 抓取搜索结果网页的主要内容（trafilatura/readability/bs4 三级降级；知乎链接走专用抓取）。
 5.  **阅读总结**: 内部LLM阅读所有搜索到的材料。
 6.  **生成答案**: LLM根据阅读的材料，生成最终的总结性答案并返回。
@@ -53,7 +54,7 @@ pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 ### `[plugin]`
 - `name` (str): 插件名称，保持默认即可。
 - `version` (str): 插件版本，保持默认即可。
-- `config_version` (str): 配置版本号，**必填**，当前 `4.0.0`。麦麦在加载插件时会校验该字段。
+- `config_version` (str): 配置版本号，**必填**，当前 `4.0.1`。麦麦在加载插件时会校验该字段。
 - `enabled` (bool): 是否启用插件。
 
 ### `[models]`
@@ -71,7 +72,7 @@ pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 ### `[search_backend]`
 这里配置供模型调用的“后端”搜索引擎的行为。
 
-- `default_engine` (str, 下拉 choices): 默认使用的搜索引擎 (`google`, `bing`, `sogou`, `duckduckgo`, `tavily`, `you`, `you_news`)。
+- `default_engine` (str, 下拉 choices): 默认使用的搜索引擎 (`google`, `bing`, `sogou`, `duckduckgo`, `tavily`, `bocha`, `you`, `you_news`)。
 - `max_results` (int): 每次搜索返回给模型阅读的结果数量。
 - `timeout` (int): 后端搜索引擎的超时时间。
 - `proxy` (str): 用于后端搜索的HTTP/HTTPS代理地址，例如 'http://127.0.0.1:7890'。默认为空字符串，表示不使用代理。
@@ -101,6 +102,10 @@ pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple
 - `tavily_include_raw_content` (bool): 是否返回网页正文片段。
 - `tavily_topic` (str): Tavily 主题参数，如 `general` 或 `news`。**v4 起默认留空**——Tavily 的 news 索引偏向英文国际体育/政治资讯，对中文电竞/娱乐/社交等场景准确率反而下降，因此不再让插件 LLM 自动判断。如有需要可由工具调用方在调用时显式传入 `tavily_topic` 参数覆写。
 - `tavily_turbo` (bool): Tavily Turbo 模式。
+- `bocha_enabled` (bool): 是否启用博查 Web Search（需 API key）。
+- `bocha_api_keys` (list[str]) / `bocha_api_key` (str): 博查 key 列表或单个（也可用环境变量 `BOCHA_API_KEY`）。
+- `bocha_freshness` (str): 博查 freshness 参数；留空表示不限时间。
+- `bocha_summary` (bool): 是否请求博查返回 summary 摘要。
 - `you_enabled` (bool): 是否启用 You Search。
 - `you_news_enabled` (bool): 是否启用 You Live News（early access）。
 - `you_api_keys` (list[str]) / `you_api_key` (str): You API key 列表或单个（也可用环境变量 `YOU_API_KEY`）。

--- a/_manifest.json
+++ b/_manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "name": "麦麦联网插件（search plugin）",
   "description": "支持多个搜索引擎的网络搜索、缩写翻译以及图片搜索，并提供自动降级能力。",
   "author": {
@@ -101,16 +101,7 @@
   ],
   "i18n": {
     "default_locale": "zh-CN",
-    "supported_locales": [
-      "zh-CN"
-    ]
+    "supported_locales": ["zh-CN"]
   },
   "id": "xxxxx7258.google-search-plugin"
 }
-
-
-
-
-
-
-

--- a/config.py
+++ b/config.py
@@ -21,8 +21,8 @@ class PluginSection(PluginConfigBase):
     __ui_order__ = 0
 
     name: str = Field(default="google_search", description="插件名称")
-    version: str = Field(default="4.0.0", description="插件版本")
-    config_version: str = Field(default="4.0.0", description="配置版本(Runner 用于兼容性校验)")
+    version: str = Field(default="4.0.1", description="插件版本")
+    config_version: str = Field(default="4.0.1", description="配置版本(Runner 用于兼容性校验)")
     enabled: bool = Field(default=True, description="是否启用插件")
 
 
@@ -78,7 +78,7 @@ class SearchBackendSection(PluginConfigBase):
     __ui_icon__ = "globe"
     __ui_order__ = 3
 
-    default_engine: Literal["google", "bing", "sogou", "duckduckgo", "tavily", "you", "you_news"] = Field(
+    default_engine: Literal["google", "bing", "sogou", "duckduckgo", "tavily", "bocha", "you", "you_news"] = Field(
         default="bing",
         description="默认搜索引擎",
     )
@@ -159,6 +159,16 @@ class EnginesSection(PluginConfigBase):
         ),
     )
     tavily_turbo: bool = Field(default=False, description="是否启用 Tavily Turbo 模式")
+
+    # Bocha
+    bocha_enabled: bool = Field(default=False, description="是否启用博查 Web Search")
+    bocha_api_keys: list[str] = Field(
+        default_factory=list,
+        description="博查 API key 列表,填写多个时随机选用",
+    )
+    bocha_api_key: str = Field(default="", description="博查 API key;留空则使用环境变量 BOCHA_API_KEY")
+    bocha_freshness: str = Field(default="", description="博查 freshness 参数;留空表示不限制时间")
+    bocha_summary: bool = Field(default=True, description="是否请求博查返回 summary 摘要")
 
     # You
     you_enabled: bool = Field(default=False, description="是否启用 You Search")

--- a/pipelines/engine_chain.py
+++ b/pipelines/engine_chain.py
@@ -10,6 +10,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Optional
 
 from ..search_engines.bing import BingEngine
+from ..search_engines.bocha import BochaEngine
 from ..search_engines.duckduckgo import DuckDuckGoEngine
 from ..search_engines.google import GoogleEngine
 from ..search_engines.sogou import SogouEngine
@@ -72,6 +73,16 @@ def _build_engine_dict(
                 "turbo": engines.tavily_turbo,
             }
         )
+    elif engine_name == "bocha":
+        cfg.update(
+            {
+                "enabled": engines.bocha_enabled,
+                "api_keys": list(engines.bocha_api_keys),
+                "api_key": engines.bocha_api_key,
+                "freshness": engines.bocha_freshness,
+                "summary": engines.bocha_summary,
+            }
+        )
     elif engine_name == "you":
         cfg.update(
             {
@@ -124,6 +135,7 @@ class EngineChain:
         self.sogou = SogouEngine(_build_engine_dict("sogou", engines, common))
         self.duckduckgo = DuckDuckGoEngine(_build_engine_dict("duckduckgo", engines, common))
         self.tavily = TavilyEngine(_build_engine_dict("tavily", engines, common))
+        self.bocha = BochaEngine(_build_engine_dict("bocha", engines, common))
         self.you = YouSearchEngine(_build_engine_dict("you", engines, common))
         self.you_news = YouLiveNewsEngine(_build_engine_dict("you_news", engines, common))
         self.you_contents = YouContentsClient(_build_engine_dict("you_contents", engines, contents_common))
@@ -151,9 +163,10 @@ class EngineChain:
         engines_cfg = self._engines_cfg
         default_engine = self._backend_cfg.default_engine
 
-        # 引擎优先级:tavily / you 系列优先(质量较高的 API 引擎),其余兜底
+        # 引擎优先级:tavily / bocha / you 系列优先(质量较高的 API 引擎),其余兜底
         all_engines: list[tuple[str, Any]] = [
             ("tavily", self.tavily),
+            ("bocha", self.bocha),
             ("you", self.you),
             ("you_news", self.you_news),
             ("google", self.google),
@@ -174,7 +187,7 @@ class EngineChain:
                 continue
 
             # 需 API key 的引擎,无 key 直接跳过
-            if engine_name in {"tavily", "you", "you_news"} and hasattr(engine, "has_api_keys"):
+            if engine_name in {"tavily", "bocha", "you", "you_news"} and hasattr(engine, "has_api_keys"):
                 if not engine.has_api_keys():
                     logger.info("%s 未配置 API key,跳过", engine_name)
                     continue

--- a/plugin.py
+++ b/plugin.py
@@ -460,6 +460,8 @@ class GoogleSearchPlugin(MaiBotPlugin):
             enabled_engines.append("duckduckgo")
         if e.tavily_enabled:
             enabled_engines.append("tavily")
+        if e.bocha_enabled:
+            enabled_engines.append("bocha")
         if e.you_enabled:
             enabled_engines.append("you")
         if e.you_news_enabled:

--- a/search_engines/__init__.py
+++ b/search_engines/__init__.py
@@ -9,6 +9,7 @@ from .google import GoogleEngine
 from .bing import BingEngine
 from .sogou import SogouEngine
 from .tavily import TavilyEngine
+from .bocha import BochaEngine
 from .you import YouSearchEngine, YouLiveNewsEngine, YouContentsClient, YouImagesEngine
 
 __all__ = [
@@ -18,6 +19,7 @@ __all__ = [
     "BingEngine",
     "SogouEngine",
     "TavilyEngine",
+    "BochaEngine",
     "YouSearchEngine",
     "YouLiveNewsEngine",
     "YouContentsClient",

--- a/search_engines/bocha.py
+++ b/search_engines/bocha.py
@@ -1,0 +1,165 @@
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from .base import ApiKeyMixin, BaseSearchEngine, SearchResult, mask_api_key
+
+logger = logging.getLogger(__name__)
+
+
+def _merge_texts(*values: str) -> str:
+    """按顺序合并非空文本,避免把 snippet 和 summary 重复塞给总结 prompt。"""
+    merged: list[str] = []
+    for value in values:
+        text = value.strip()
+        if text and text not in merged:
+            merged.append(text)
+    return "\n".join(merged)
+
+
+class BochaEngine(BaseSearchEngine, ApiKeyMixin):
+    """Bocha Web Search API client."""
+
+    BASE_URL = "https://api.bochaai.com"
+    SEARCH_ENDPOINT = "/v1/web-search"
+    API_MAX_RESULTS = 50
+
+    freshness: Optional[str]
+    summary: bool
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__(config)
+        self._init_api_keys(self.config, "BOCHA_API_KEY")
+
+        freshness_cfg = self.config.get("freshness")
+        if isinstance(freshness_cfg, str):
+            freshness_cfg = freshness_cfg.strip()
+        self.freshness = freshness_cfg or None
+        self.summary = bool(self.config.get("summary", True))
+
+    async def search(self, query: str, num_results: int) -> List[SearchResult]:
+        """Execute a Bocha web-search request."""
+        api_keys = self._iter_api_keys()
+        if not api_keys:
+            logger.warning("Bocha API key is not configured; skip Bocha search.")
+            return []
+
+        request_count = self._request_count(num_results)
+        payload: Dict[str, Any] = {
+            "query": query,
+            "summary": self.summary,
+            "count": request_count,
+        }
+        if self.freshness:
+            payload["freshness"] = self.freshness
+
+        timeout = aiohttp.ClientTimeout(total=self.TIMEOUT)
+        headers_base = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            for api_key in api_keys:
+                headers = {
+                    **headers_base,
+                    "Authorization": f"Bearer {api_key}",
+                }
+                try:
+                    async with session.post(
+                        f"{self.BASE_URL}{self.SEARCH_ENDPOINT}",
+                        json=payload,
+                        headers=headers,
+                        proxy=self.proxy,
+                    ) as response:
+                        response_text = await response.text()
+                        if response.status >= 400:
+                            logger.error(
+                                "Bocha search request failed with status %s for key %s; response body: %s",
+                                response.status,
+                                mask_api_key(api_key),
+                                response_text,
+                            )
+                            continue
+
+                        if not response_text:
+                            logger.error("Bocha returned an empty response for key %s.", mask_api_key(api_key))
+                            continue
+
+                        try:
+                            data = json.loads(response_text)
+                        except json.JSONDecodeError:
+                            logger.error(
+                                "Failed to parse Bocha response as JSON for key %s: %s",
+                                mask_api_key(api_key),
+                                response_text,
+                            )
+                            continue
+
+                except Exception as exc:
+                    logger.error(
+                        "Bocha search raised an exception for key %s: %s",
+                        mask_api_key(api_key),
+                        exc,
+                        exc_info=True,
+                    )
+                    continue
+
+                if not isinstance(data, dict):
+                    logger.error(
+                        "Unexpected Bocha response type for key %s: %s",
+                        mask_api_key(api_key),
+                        type(data),
+                    )
+                    continue
+
+                web_pages = data.get("webPages") or {}
+                items = web_pages.get("value") if isinstance(web_pages, dict) else None
+                if not isinstance(items, list):
+                    logger.error(
+                        "Unexpected Bocha webPages.value for key %s: %s",
+                        mask_api_key(api_key),
+                        type(items),
+                    )
+                    continue
+
+                results = self._parse_results(items)
+                return results[:request_count]
+
+        return []
+
+    def _request_count(self, num_results: int) -> int:
+        configured_max = self.max_results if self.max_results > 0 else self.API_MAX_RESULTS
+        requested = num_results if num_results > 0 else configured_max
+        return max(1, min(requested, configured_max, self.API_MAX_RESULTS))
+
+    def _parse_results(self, items: List[Any]) -> List[SearchResult]:
+        results: List[SearchResult] = []
+
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+
+            title = self.tidy_text(item.get("name", ""))
+            url = item.get("url", "")
+            if not title or not self._is_valid_url(url):
+                continue
+
+            snippet = self.tidy_text(item.get("snippet", ""))
+            summary = self.tidy_text(item.get("summary", ""))
+            abstract = _merge_texts(snippet, summary)
+
+            results.append(
+                SearchResult(
+                    title=title,
+                    url=url,
+                    snippet=snippet,
+                    abstract=abstract,
+                    rank=index,
+                    content=summary,
+                )
+            )
+
+        return results


### PR DESCRIPTION
支持博查的搜索后端

## Summary by Sourcery

添加 Bocha Web Search 作为可配置的后端，并将插件/配置版本提升至 4.0.1。

New Features:
- 引入 Bocha Web Search 引擎实现，并将其集成到引擎链中，支持回退机制。
- 提供 Bocha 搜索的配置选项（启用标志、API 密钥、新鲜度、摘要），并允许将其设置为默认搜索引擎。

Enhancements:
- 更新插件和配置的元数据及 README，以体现版本 4.0.1，并说明 Bocha 后端的使用方式。

Documentation:
- 记录 Bocha Web Search 的设置步骤、API 密钥要求，并将其纳入搜索流程说明和配置示例中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Bocha Web Search as a configurable backend and bump plugin/config version to 4.0.1.

New Features:
- Introduce Bocha Web Search engine implementation and integrate it into the engine chain with fallback support.
- Expose Bocha search configuration options (enable flag, API keys, freshness, summary) and allow selecting it as the default search engine.

Enhancements:
- Update plugin and config metadata and README to reflect version 4.0.1 and describe Bocha backend usage.

Documentation:
- Document Bocha Web Search setup, API key requirements, and include it in the described search workflow and configuration examples.

</details>