### PR TITLE
feat: 支持 Tavily 高级结果与受控正文总结

### DIFF
--- a/config.py
+++ b/config.py
@@ -146,8 +146,14 @@ class EnginesSection(PluginConfigBase):
     )
     tavily_api_key: str = Field(default="", description="Tavily API key;留空则使用环境变量 TAVILY_API_KEY")
     tavily_search_depth: Literal["basic", "advanced"] = Field(default="basic", description="搜索深度")
-    tavily_include_raw_content: bool = Field(default=False, description="是否返回网页原始内容")
-    tavily_include_answer: bool = Field(default=True, description="是否返回 Tavily 生成的答案")
+    tavily_include_raw_content: Literal[False, True, "markdown", "text"] = Field(
+        default=False,
+        description="是否返回网页正文；markdown 保留 Markdown 结构，text 返回纯文本。",
+    )
+    tavily_include_answer: Literal[False, True, "basic", "advanced"] = Field(
+        default="basic",
+        description="是否返回 Tavily 聚合答案；advanced 返回更详细的答案。",
+    )
     tavily_topic: str = Field(
         default="",
         description=(
@@ -157,6 +163,19 @@ class EnginesSection(PluginConfigBase):
         ),
     )
     tavily_turbo: bool = Field(default=False, description="是否启用 Tavily Turbo 模式")
+
+    summary_source_max_chars: int = Field(
+        default=1600,
+        ge=200,
+        le=10000,
+        description="搜索总结中每个来源最多保留的字符数，避免正文过长。",
+    )
+    summary_total_max_chars: int = Field(
+        default=12000,
+        ge=1000,
+        le=50000,
+        description="搜索总结中全部来源最多保留的字符数。",
+    )
 
     # You
     you_enabled: bool = Field(default=False, description="是否启用 You Search")

--- a/pipelines/prompts.py
+++ b/pipelines/prompts.py
@@ -87,19 +87,41 @@ def build_url_summarize_prompt(*, bot_name: str, url: str, content: str) -> str:
     ).strip()
 
 
-def format_results_for_prompt(results: "list[SearchResult]") -> str:
+def format_results_for_prompt(
+    results: "list[SearchResult]",
+    *,
+    source_max_chars: int,
+    total_max_chars: int,
+) -> str:
     """格式化搜索结果用于 summarize prompt 的 ``[搜索到的资料]`` 段。
 
     Args:
         results: 搜索结果列表
     """
     lines: list[str] = []
+    total_chars = 0
     for idx, result in enumerate(results, start=1):
+        if total_chars >= total_max_chars:
+            break
+
         header = f"{idx}. {result.title}"
         if result.url:
             header += f" {result.url}"
         lines.append(header)
-        if result.abstract:
-            lines.append(result.abstract)
+
+        remaining_chars = min(source_max_chars, total_max_chars - total_chars)
+        abstract = (result.abstract or result.snippet or "").strip()
+        content = (result.content or "").strip()
+        if abstract:
+            abstract_excerpt = abstract[:remaining_chars]
+            lines.append(f"摘要：{abstract_excerpt}")
+            total_chars += len(abstract_excerpt)
+            remaining_chars -= len(abstract_excerpt)
+
+        # Tavily 的 raw_content 会写入 content；仅在它不同于摘要且仍有预算时附带正文。
+        if content and content != abstract and remaining_chars > 0:
+            content_excerpt = content[:remaining_chars]
+            lines.append(f"正文摘录：{content_excerpt}")
+            total_chars += len(content_excerpt)
         lines.append("")
     return "\n".join(lines).strip()

--- a/pipelines/search_pipeline.py
+++ b/pipelines/search_pipeline.py
@@ -73,7 +73,11 @@ class SearchPipeline:
             results = await self._fetcher.fetch_batch(results, last_success_engine=last_engine)
 
         # ---- 3. summarize prompt ---- #
-        formatted = format_results_for_prompt(results)
+        formatted = format_results_for_prompt(
+            results,
+            source_max_chars=self._backend.summary_source_max_chars,
+            total_max_chars=self._backend.summary_total_max_chars,
+        )
         summarize_prompt = build_summarize_prompt(
             bot_name=bot_name,
             question=question,

--- a/search_engines/tavily.py
+++ b/search_engines/tavily.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 import aiohttp
 
@@ -16,8 +16,8 @@ class TavilyEngine(BaseSearchEngine, ApiKeyMixin):
     SEARCH_ENDPOINT = "/search"
 
     search_depth: str
-    include_raw_content: bool
-    include_answer: bool
+    include_raw_content: Literal[False, True, "markdown", "text"]
+    include_answer: Literal[False, True, "basic", "advanced"]
     topic: Optional[str]
     turbo: bool
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,31 @@
+"""提示词结果格式化测试。"""
+
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from pipelines.prompts import format_results_for_prompt
+from search_engines.base import SearchResult
+
+
+def test_format_results_limits_raw_content_per_source() -> None:
+    """原始正文应计入单来源字符上限，避免提示词无限增长。"""
+    result = SearchResult(
+        title="示例来源",
+        url="https://example.com",
+        snippet="abc",
+        abstract="abc",
+        content="x" * 100,
+    )
+
+    formatted = format_results_for_prompt(
+        [result],
+        source_max_chars=10,
+        total_max_chars=10,
+    )
+
+    assert "摘要：abc" in formatted
+    assert "正文摘录：xxxxxxx" in formatted
+    assert "正文摘录：xxxxxxxx" not in formatted


### PR DESCRIPTION
## 关联 Issue

Closes #49

## 改动

- 扩展 Tavily 配置以支持 API 原生的 `markdown`、`text`、`basic` 和 `advanced` 返回模式。
- 保留既有 `true/false` 配置，避免已部署实例升级后出现配置校验错误。
- 将 Tavily `raw_content` 以“正文摘录”加入总结资料，只有在与摘要不同时才附带。
- 新增单来源和全部来源字符上限，控制总结模型的输入体积。
- 添加提示词格式化测试，覆盖正文摘录的单来源截断。

## 配置示例

```toml
[engines]
tavily_search_depth = "advanced"
tavily_include_raw_content = "markdown"
tavily_include_answer = "advanced"
summary_source_max_chars = 3000
summary_total_max_chars = 24000
```

## 验证

- `uv run pytest plugins/xxxxx7258_google-search-plugin/tests/test_prompts.py`
- `uv run python -m compileall -q ...`
- `git diff --check`

未包含本地 `config.toml`、API Key 或 `config_back/`。